### PR TITLE
Set to be Replete 2.0

### DIFF
--- a/RepleteMacOS/Info.plist
+++ b/RepleteMacOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>2.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
This may seem a little odd to call it Replete 2.0, but that essentially where we are (Replete 2.0 added HTTP and file I/O, as well as the Android version.)