### PR TITLE
Multiline formatting

### DIFF
--- a/RepleteMacOS/ViewController.swift
+++ b/RepleteMacOS/ViewController.swift
@@ -126,7 +126,7 @@ extension ViewController {
             }
             s.addAttribute(NSAttributedString.Key.paragraphStyle,
                            value: paragraphStyle as Any,
-                           range: NSMakeRange(0, s.length));
+                           range: NSMakeRange(0, 1));
             
             // Make the color of input gray
             


### PR DESCRIPTION
We really only want the spacing to be applied
to the first line. This revision achieves that by
only applying the paragraph style to the first
character.

Here is a sample after the change:

<img width="443" alt="image" src="https://user-images.githubusercontent.com/1723464/56839937-f9db0c00-6852-11e9-8317-a4df7bed3ec1.png">
