### PR TITLE
Bundle Identifier

### DIFF
--- a/Replete.xcodeproj/project.pbxproj
+++ b/Replete.xcodeproj/project.pbxproj
@@ -604,7 +604,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.wildthink.osx.Replete;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fikesfarm.macos.Replete;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "CSContext/Replete-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -626,7 +626,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.wildthink.osx.Replete;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fikesfarm.macos.Replete;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "CSContext/Replete-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/Replete/Info.plist
+++ b/Replete/Info.plist
@@ -29,6 +29,10 @@
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleHelpBookFolder</key>
+	<string>$(PROJECT_NAME)Help.help</string>
+	<key>CFBundleHelpBookName</key>
+	<string>com.fikesfarm.macos.$(PROJECT_NAME:rfc1034identifier).help</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
@@ -51,9 +55,5 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>CFBundleHelpBookName</key>
-	<string>com.wildthink.osx.$(PROJECT_NAME:rfc1034identifier).help</string>
-	<key>CFBundleHelpBookFolder</key>
-	<string>$(PROJECT_NAME)Help.help</string>
 </dict>
 </plist>


### PR DESCRIPTION
Looks like we lost #21 ; this adds it back but tweaks the id to be distinct from the one used for Replete iOS.