### PR TITLE
Content inset tweaks

### DIFF
--- a/Replete/Base.lproj/Main.storyboard
+++ b/Replete/Base.lproj/Main.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -752,22 +753,23 @@ DQ
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="bar" spellingCorrection="YES" smartInsertDelete="YES" id="Qxg-df-C9U">
-                                                            <rect key="frame" x="0.0" y="0.0" width="500" height="310"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="490" height="300"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            <size key="minSize" width="500" height="310"/>
+                                                            <size key="minSize" width="490" height="300"/>
                                                             <size key="maxSize" width="500" height="10000000"/>
                                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                         </textView>
                                                     </subviews>
                                                 </clipView>
+                                                <edgeInsets key="contentInsets" left="2" right="2" top="5" bottom="5"/>
                                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="OKl-cz-al5">
                                                     <rect key="frame" x="-100" y="-100" width="240" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </scroller>
                                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="ejR-bb-cwg">
-                                                    <rect key="frame" x="484" y="0.0" width="16" height="310"/>
+                                                    <rect key="frame" x="482" y="5" width="16" height="300"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </scroller>
                                             </scrollView>
@@ -790,22 +792,23 @@ DQ
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="bar" spellingCorrection="YES" smartInsertDelete="YES" id="SSS-Ar-UXL">
-                                                            <rect key="frame" x="0.0" y="0.0" width="500" height="80"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="492" height="69"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            <size key="minSize" width="500" height="80"/>
+                                                            <size key="minSize" width="492" height="69"/>
                                                             <size key="maxSize" width="500" height="10000000"/>
                                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                         </textView>
                                                     </subviews>
                                                 </clipView>
+                                                <edgeInsets key="contentInsets" left="2" right="2" top="6" bottom="5"/>
                                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="ziJ-2X-EV8">
                                                     <rect key="frame" x="-100" y="-100" width="240" height="16"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </scroller>
                                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="r3f-Ve-Tkh">
-                                                    <rect key="frame" x="484" y="0.0" width="16" height="80"/>
+                                                    <rect key="frame" x="482" y="6" width="16" height="69"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </scroller>
                                             </scrollView>


### PR DESCRIPTION
Tweaks content insets for the text views so that there is a pleasing amount of whitespace between text and edge.

<img width="864" alt="Napkin 05-04-19, 5 54 07 PM" src="https://user-images.githubusercontent.com/1723464/57185232-9d50a000-6e95-11e9-8126-444f6cbf3640.png">
