### PR TITLE
Update to latest shared, set to 2.1

### DIFF
--- a/ClojureScript/replete/deps.edn
+++ b/ClojureScript/replete/deps.edn
@@ -1,3 +1,3 @@
 {:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}
         github-replete-repl/replete-shared {:git/url "https://github.com/replete-repl/replete-shared"
-                                            :sha "b8fb0bcf749578ddd010b5ece1e3fefb90f9e2d5"}}}
+                                            :sha "a5a3493021eb3539f954c69e00ecd76bc6167345"}}}

--- a/Replete/Info.plist
+++ b/Replete/Info.plist
@@ -44,7 +44,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
This updates to the latest shared code (which abbreviates vars and qualified keywords, properly print `#queue` s, etc).

This also updates the version to 2.1 (which may be the first version to go in the app store), but this would be consistent with the other Repletes that have the latest shared code as well. This may seem odd to have the first release be 2.1, but at least it is consistent. ¯\_(ツ)_/¯