### PR TITLE
Copy only text from history

### DIFF
--- a/Replete/ViewController.swift
+++ b/Replete/ViewController.swift
@@ -236,7 +236,7 @@ extension ViewController {
         if let rng = selectedHistoryRange, let ts = outputTextView.textStorage {
             outputTextView.setSelectedRange(rng)
             outputTextView.scrollRangeToVisible(rng)
-            let str = ts.attributedSubstring(from: rng)
+            let str = ts.attributedSubstring(from: rng).string
             inputTextView.insertText(str, replacementRange: inputTextView.fullRange)
         }
     }


### PR DESCRIPTION
When copying history from output pane to input pane, strip off formatting.

This way the input pane retains its black-on-white formatting with proper line spacing, etc.