### PR TITLE
Use strong for JS context references

### DIFF
--- a/CSContext/CSContext.m
+++ b/CSContext/CSContext.m
@@ -24,7 +24,7 @@
 @interface CSContext ()
 
 @property (assign, nonatomic) JSGlobalContextRef ctx; // jmj
-@property (assign, nonatomic) JSContext* context;
+@property (strong, nonatomic) JSContext* context;
 @property (strong, nonatomic) JSValue* readEvalPrintFn;
 @property (strong, nonatomic) JSValue* chivorcamReferred;
 @property (strong, nonatomic) JSValue* formatFn;


### PR DESCRIPTION
Fixes #70